### PR TITLE
github: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: ventoy-cpio release
+
+# creates a manually-activatable workflow run button
+# in the GitHub Actions web UI
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: The tag or branch name to build from and upload into
+        required: true
+      release_description:
+        description: Description that will be visible in the release page
+        required: true
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.event.inputs.release_tag }}
+
+      # prevents "mkdir: cannot create directory 'build': Permission denied"
+      # during the execution of cpio.base.mk
+      - name: Set permissive repository permissions for docker
+        run: chmod -R 777 .
+
+      - name: Run docker compose
+        run: |
+          docker compose build
+          docker compose up --abort-on-container-failure
+          docker compose down
+
+      # prevents "xz: dist/ventoy.cpio.xz: Permission denied"
+      # during the compression of artifacts
+      - name: Set ownership permissions on artifacts
+        run: |
+          sudo chown -R $(whoami) dist
+          sudo chgrp -R docker dist
+
+      - name: Compress artifacts
+        run: |
+          for artifact in dist/ventoy*; do
+            xz -v $artifact
+          done
+
+      - name: Create release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.inputs.release_tag }}
+          body: ${{ github.event.inputs.release_description }}
+          file: dist/ventoy*
+          overwrite: true
+          file_glob: true

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -6,6 +6,25 @@ include info.mk
 all: build
 build: $(TOOLS)
 
+
+# intermittent failure here
+
+# Example 1:
+# make[3]: *** [source.mk:7: device-mapper.1.02.28.tgz] Error 4
+# make[3]: Leaving directory '/build/tools/device-mapper'
+# make[2]: Leaving directory '/build/tools/device-mapper'
+# make[2]: *** [Makefile:11: src] Error 2
+# make[1]: *** [Makefile:11: device-mapper] Error 2
+# make[1]: *** Waiting for unfinished jobs....
+
+# Example 2:
+# make[3]: *** [source.mk:7: lunzip-1.11.tar.gz] Error 4
+# checking for musl-gcc option to accept ISO C89... make[3]: Leaving directory '/build/tools/lunzip'
+# make[2]: Leaving directory '/build/tools/lunzip'
+# make[2]: *** [Makefile:11: src] Error 2
+# make[1]: *** [Makefile:11: lunzip] Error 2
+# make -f build.mk TARGET=x86_64-ash
+# make[1]: *** Waiting for unfinished jobs....
 .PHONY: $(TOOLS)
 $(TOOLS):
 	+$(MAKE) -C $@


### PR DESCRIPTION
- Adds a basic GitHub Actions release workflow that can be run whenever desired by going to the Actions tab of the GitHub web UI and clicking on the Workflow Dispatch Button

- https://github.com/fnr1r/ventoy-cpio/commit/38218d7b170f7a269790b2a4dd25e70dd2963622 seemed to miss the patch download step, resulting in the error `patch: **** Can't open patch file /tmp/dietlibc/newer-linux-headers.diff : No such file or directory`, so I added a patch download step to `docker/base/dietlibc/setup.sh`

- Clean builds of ventoy-cpio currently have an intermittent error (an error that happens only sometimes) `*** [source.mk:7: device-mapper.1.02.28.tgz] Error 4`. This adds a comment about it, but does not fix that error.